### PR TITLE
Add new product to a group test

### DIFF
--- a/cypress/e2e/add_product.cy.js
+++ b/cypress/e2e/add_product.cy.js
@@ -39,5 +39,11 @@ cy.get(selectors.productsMenu.nameCase).type('Test')
     cy.get('.MuiDialog-container').contains('Product deleted successfully')
   });
 
+  it.only('Can add a product as part of a group', ()=>{
+    cy.get(selectors.mainPage.menuOptions).click();
+    cy.get(selectors.mainPage.productsTab).click();
+    cy.get(selectors.productsMenu.inventoryButton).click();
+  })
+
 });
 

--- a/cypress/e2e/api/tests/helpers/products-api-helper.js
+++ b/cypress/e2e/api/tests/helpers/products-api-helper.js
@@ -1,0 +1,9 @@
+export class ProductsApiHelper {
+    endpoint = 'partner/product-groups'
+  
+    createProductsGroup(authToken, productsGroupData) {
+      const url = `${this.endpoint}`
+      return cy.postRequest(url, productsGroupData, authToken, 'application/json', false).as('createProduct')
+    }
+  }
+  

--- a/cypress/e2e/ui/tests/pages/navigation-menu.js
+++ b/cypress/e2e/ui/tests/pages/navigation-menu.js
@@ -19,5 +19,11 @@ export class NavigationMenu {
         cy.contains('Team Members').click({ force: true })
 
     }
+
+    navigateToInventory(){
+        cy.contains('Products').click({ force: true })
+        cy.contains('Inventory').click({ force: true })
+
+    }
         
 }

--- a/cypress/e2e/ui/tests/pages/products-page.js
+++ b/cypress/e2e/ui/tests/pages/products-page.js
@@ -1,0 +1,11 @@
+import { selectors } from '../../../../support/selectors.js'
+
+export class ProductsPage {
+    constructor() {}
+
+    createNewProductInGroup({ productName, productGroupData }) {
+        cy.contains('Add Product').click()                
+        cy.get('[placeholder="Product Name"]').type(productName)
+        cy.contains('label', 'Select a group...').parent().find('input').type(productGroupData.name).type('{enter}')
+    }
+}

--- a/cypress/e2e/ui/tests/specs/products-ui-testsuite.cy.js
+++ b/cypress/e2e/ui/tests/specs/products-ui-testsuite.cy.js
@@ -1,0 +1,48 @@
+import { ProductsPage } from "../pages/products-page.js"
+import { LoginPage } from "../pages/login-page"
+import { NavigationMenu } from "../pages/navigation-menu"
+import { ProductsApiHelper } from "../../../api/tests/helpers/products-api-helper.js"
+import { faker } from '@faker-js/faker'
+
+const productsApiHelper = new ProductsApiHelper()
+const productsPage = new ProductsPage()
+const loginPage = new LoginPage()
+const navigationMenu = new NavigationMenu()
+
+describe('Products Test Suite', () => {
+    beforeEach(() => {
+        cy.clearAllCookies()
+        cy.clearLocalStorage()
+        cy.visit(Cypress.env('baseUrl'))
+        cy.loginByAPI()
+    })
+
+    it('should successfully create a new product in a products group', () => {
+        cy.get('@authToken').then((token) => {
+          
+            const productGroupName = `Prod Group-${faker.number.int({ min: 1000, max: 9999 })}`
+            const productName = `Prod-${faker.number.int({ min: 1000, max: 9999 })}`
+
+            loginPage.login(Cypress.env('username'), Cypress.env('password'))
+            navigationMenu.navigateToInventory()
+
+            const productGroupData = {
+                "auto_repair": false,
+                "name": productGroupName,
+                "total_inventory": 0,
+                "charging_time": 0,
+                "id_size": null,
+                "one_to_one": true,
+                "products": []
+            }
+
+            productsApiHelper.createProductsGroup(token, productGroupData).then((groupDataInfo) => {
+                productsPage.createNewProductInGroup({ productName, productGroupData })
+            })
+
+            // Assertions
+            cy.contains('h2', 'Success').should('be.visible')        
+            cy.contains('p', 'Product created successfully!').should('be.visible')
+        })
+    })
+})


### PR DESCRIPTION
Implements the product creation flow in the UI with randomly generated names for both the product and product group.
Key Changes:
Added ProductsPage class with createNewProductInGroup method for UI product creation.
Integrated Faker for generating random names:
        Product: Prod-XXXX
        Product Group: Prod Group-XXXX
Created Products Test Suite to validate product creation success message.
Used ProductsApiHelper to create product groups via API.


https://github.com/user-attachments/assets/cd67952c-3107-480e-864e-9ad003407175

