### PR TITLE
Kd3276 add user to group

### DIFF
--- a/cypress/e2e/api/tests/helpers/users-api-helper.js
+++ b/cypress/e2e/api/tests/helpers/users-api-helper.js
@@ -1,9 +1,17 @@
 export class UsersApiHelper {
-    endpoint = 'partner/users'
-  
+    users_endpoint = 'partner/users'
+    groups_endpoint = 'partner/groups'
+
     createUser(authToken, userData) {
-      const url = `${this.endpoint}`
+      const url = `${this.users_endpoint}`
       return cy.postRequest(url, userData, authToken, 'application/json', false).as('createUser')
     }
+    createGroup(authToken, groupData) {
+      const { name, ...restData } = groupData
+      const url = `${this.groups_endpoint}?name=${encodeURIComponent(name)}`    
+      
+      return cy.postRequest(url, restData, authToken, 'application/json', false).as('createGroup')
+    }
+    
   }
   

--- a/cypress/e2e/api/tests/helpers/users-api-helper.js
+++ b/cypress/e2e/api/tests/helpers/users-api-helper.js
@@ -12,6 +12,18 @@ export class UsersApiHelper {
       
       return cy.postRequest(url, restData, authToken, 'application/json', false).as('createGroup')
     }
+
+    getUserByID(authToken, id){
+      const url = `${this.users_endpoint}?search=${id}&page=1&size=50&by_email=false&by_user_id=true&all_pages=false&exact_match=false`;
+
+      return cy.getRequest(url, authToken).as('getResponse')
+    }
+
+    deleteUserById(authToken, userId) {
+      const body = [userId]      
+      return cy.deleteRequest(this.users_endpoint, body, authToken).as('deleteResponse')
+    }
+    
     
   }
   

--- a/cypress/e2e/ui/tests/pages/navigation-menu.js
+++ b/cypress/e2e/ui/tests/pages/navigation-menu.js
@@ -17,7 +17,11 @@ export class NavigationMenu {
     navigateToTeamMembers(){
         cy.contains('People').click({ force: true })
         cy.contains('Team Members').click({ force: true })
+    }
 
+    navigateToUsers(){
+        cy.contains('People').click({ force: true })
+        cy.get('div.MuiListItemText-root').contains('Users').click();
     }
 
     navigateToInventory(){

--- a/cypress/e2e/ui/tests/pages/users-page.js
+++ b/cypress/e2e/ui/tests/pages/users-page.js
@@ -13,7 +13,5 @@ export class UsersPage {
         cy.get(selectors.addUserForm.userId).type(id)
         cy.get(selectors.addUserForm.pinCode).type(pin)
         cy.get(selectors.addUserForm.group).type(groupName).type('{enter}')
-        //cy.contains('Submit').click()
-        
     }
 }

--- a/cypress/e2e/ui/tests/pages/users-page.js
+++ b/cypress/e2e/ui/tests/pages/users-page.js
@@ -1,0 +1,19 @@
+import { selectors } from '../../../../support/selectors.js';
+
+export class UsersPage {
+    constructor() {}
+
+    createNewUserInAGroup({groupName, name, lastName, phone, address, id, pin}) {
+        cy.contains("Add User").click()
+            
+        cy.get(selectors.addUserForm.name).type(name)
+        cy.get(selectors.addUserForm.lastName).type(lastName)
+        cy.get(selectors.addUserForm.phoneNumber).type(phone)
+        cy.get(selectors.addUserForm.address).type(address)
+        cy.get(selectors.addUserForm.userId).type(id)
+        cy.get(selectors.addUserForm.pinCode).type(pin)
+        cy.get(selectors.addUserForm.group).type(groupName).type('{enter}')
+        //cy.contains('Submit').click()
+        
+    }
+}

--- a/cypress/e2e/ui/tests/specs/users-ui-testsuite.cy.js
+++ b/cypress/e2e/ui/tests/specs/users-ui-testsuite.cy.js
@@ -1,0 +1,51 @@
+import { LoginPage } from "../pages/login-page.js"
+import { NavigationMenu } from "../pages/navigation-menu.js"
+import { faker } from '@faker-js/faker'
+import { UsersPage } from "../pages/users-page.js"
+import { UsersApiHelper } from "../../../api/tests/helpers/users-api-helper.js"
+
+const usersPage = new UsersPage()
+const loginPage = new LoginPage()
+const usersApiHelper = new UsersApiHelper()
+const navigationMenu = new NavigationMenu()
+
+describe('Users Test Suite', () => {
+    beforeEach(() => {
+        cy.clearAllCookies()
+        cy.clearLocalStorage()
+        cy.visit(Cypress.env('baseUrl'))
+        cy.loginByAPI()
+    })
+
+        it(`should successfully create a new user and add it to a group`, () => {
+            cy.loginByAPI()
+
+            const groupData = {
+                "name": `Group_${faker.string.numeric(4)}`,                             
+            };
+            
+
+            cy.get('@authToken').then((token) => {
+                usersApiHelper.createGroup(token, groupData)
+            })
+
+            loginPage.login(Cypress.env('username'), Cypress.env('password'))
+            navigationMenu.navigateToUsers()
+
+            usersPage.createNewUserInAGroup({
+                groupName: groupData.name,
+                name: faker.person.firstName(),
+                lastName: faker.person.lastName(),
+                phone: faker.phone.number({ style: 'international' }), 
+                address: "Test Address",
+                id: faker.number.int({ min: 1000, max: 9999 }),
+                pin: faker.number.int({ min: 1000, max: 9999 })
+            });
+            
+            
+            // Assertions:
+            cy.contains('h2', 'Success').should('be.visible')
+            cy.contains('p', 'User created correctly').should('be.visible')
+
+        })
+})

--- a/cypress/e2e/ui/tests/specs/users-ui-testsuite.cy.js
+++ b/cypress/e2e/ui/tests/specs/users-ui-testsuite.cy.js
@@ -19,6 +19,7 @@ describe('Users Test Suite', () => {
 
         it(`should successfully create a new user and add it to a group`, () => {
             cy.loginByAPI()
+            const userID = faker.number.int({ min: 1000, max: 9999 })
 
             const groupData = {
                 "name": `Group_${faker.string.numeric(4)}`,                             
@@ -38,14 +39,22 @@ describe('Users Test Suite', () => {
                 lastName: faker.person.lastName(),
                 phone: faker.phone.number({ style: 'international' }), 
                 address: "Test Address",
-                id: faker.number.int({ min: 1000, max: 9999 }),
+                id: userID,
                 pin: faker.number.int({ min: 1000, max: 9999 })
-            });
-            
+            })            
             
             // Assertions:
             cy.contains('h2', 'Success').should('be.visible')
             cy.contains('p', 'User created correctly').should('be.visible')
 
+            cy.get('@authToken').then((token) => {
+                usersApiHelper.getUserByID(token, userID).then((getUser)=>{                    
+                    const createdUserId = getUser.body.items[0].id
+                    usersApiHelper.deleteUserById(token, createdUserId)
+                    usersApiHelper.deleteUserById(token, createdUserId).then((deleteResponse) => {
+                        expect(deleteResponse.status).to.eq(200)
+                      })
+                })
+            })
         })
 })

--- a/cypress/e2e/ui/tests/specs/users-ui-testsuite.cy.js
+++ b/cypress/e2e/ui/tests/specs/users-ui-testsuite.cy.js
@@ -37,7 +37,7 @@ describe('Users Test Suite', () => {
                 groupName: groupData.name,
                 name: faker.person.firstName(),
                 lastName: faker.person.lastName(),
-                phone: faker.phone.number({ style: 'international' }), 
+                phone: '+18337081299', 
                 address: "Test Address",
                 id: userID,
                 pin: faker.number.int({ min: 1000, max: 9999 })

--- a/cypress/support/selectors.js
+++ b/cypress/support/selectors.js
@@ -145,6 +145,15 @@ bulkUploadtab: '.MuiTab-root' ,
 
         
     },
+    addUserForm:{
+        name:"[placeholder='Name']",
+        lastName:"[placeholder='Last Name']",
+        phoneNumber:"[placeholder='Enter phone number here']",
+        address:"[placeholder='Address']",
+        userId:"[placeholder='User ID']",
+        pinCode:"[placeholder='0000']",
+        group: "input[aria-autocomplete='list']",
+    }
 
 }
 


### PR DESCRIPTION

https://github.com/user-attachments/assets/367e0ced-f939-44b3-90db-cf87f7c8595d

### PR Title: Add Cypress Test for Group and User Management

#### Description:
This PR introduces a new automated test that covers the following functionality:
- Creating a Group by API as precondition for the test.
- Creating a User by UI
- Adding the User to the newly created Group by UI
- Cleaning up by deleting both the Group and the User by API to ensure the test environment remains ready for subsequent test runs.

#### Impact:
- Adds coverage for critical operations related to Group and User management.
- Ensures no residual data affects other test runs, maintaining a consistent testing environment.

#### Testing Details:
- Verified successful creation of Users.
- Confirmed the User is correctly added to the Group.
- Ensured that the cleanup operations remove all test data effectively.