### PR TITLE
KD-3251 Feat: add size by UI test

### DIFF
--- a/cypress/e2e/api/tests/helpers/sizes-api-helper.js
+++ b/cypress/e2e/api/tests/helpers/sizes-api-helper.js
@@ -9,5 +9,14 @@ export class SizesApiHelper {
     getSizes(authToken){
         return cy.getRequest(this.endpoint, authToken).as('getSizes')
     }
+
+    getSizeByName(authToken, name){
+        return cy.getRequest(this.endpoint + '?key=name&value=' + name, authToken).as('getSizebyName')
+    }
+
+    deleteSize(authToken, id){
+      const body = [id]
+      return cy.deleteRequest(this.endpoint, body, authToken).as('deleteSize')
+    }
   }
   

--- a/cypress/e2e/api/tests/specs/devices.cy.js
+++ b/cypress/e2e/api/tests/specs/devices.cy.js
@@ -1,7 +1,7 @@
 import { DevicesApiHelper } from '../helpers/devices-api-helper';
 import { LocationsApiHelper } from '../helpers/locations-api-helper';
 import { SizesApiHelper } from '../helpers/sizes-api-helper';
-import { sizeData, locationData } from '../../support/data.cy.js';
+import { sizeData, locationData } from '../../../../support/data.cy.js';
 
 const devicesApiHelper = new DevicesApiHelper()
 const locationsApiHelper = new LocationsApiHelper()

--- a/cypress/e2e/api/tests/specs/sizes.cy.js
+++ b/cypress/e2e/api/tests/specs/sizes.cy.js
@@ -1,5 +1,5 @@
 import { SizesApiHelper } from "../helpers/sizes-api-helper";
-import { sizeData } from '../../support/data.cy.js';
+import { sizeData } from '../../../../support/data.cy.js';
 
 const sizesApiHelper = new SizesApiHelper()
 

--- a/cypress/e2e/ui/tests/pages/navigation-menu.js
+++ b/cypress/e2e/ui/tests/pages/navigation-menu.js
@@ -23,7 +23,11 @@ export class NavigationMenu {
     navigateToInventory(){
         cy.contains('Products').click({ force: true })
         cy.contains('Inventory').click({ force: true })
+    }
 
+    navigateToSizes(){
+        cy.contains('Doors').click({ force: true })
+        cy.contains('Sizes').click({ force: true })
     }
         
 }

--- a/cypress/e2e/ui/tests/pages/sizes-page.js
+++ b/cypress/e2e/ui/tests/pages/sizes-page.js
@@ -1,0 +1,15 @@
+import { selectors } from '../../../../support/selectors.js'
+
+export class SizesPage {
+    constructor() {}
+
+    createNewSize({ sizeName, sizeDescription, sizeWidth, sizeDepth, sizeHeight }) {
+        cy.contains('Add Size').click()                
+        cy.get('[placeholder="Name"]').type(sizeName)
+        cy.get('[placeholder="Description"]').type(sizeDescription)
+        cy.get('[placeholder="Width"]').type(sizeWidth)
+        cy.get('[placeholder="Depth"]').type(sizeDepth)
+        cy.get('[placeholder="Height"]').type(sizeHeight)
+        cy.contains('Submit').click()
+    }
+}

--- a/cypress/e2e/ui/tests/specs/sizes-ui-testsuite.cy.js
+++ b/cypress/e2e/ui/tests/specs/sizes-ui-testsuite.cy.js
@@ -1,0 +1,53 @@
+import { LoginPage } from "../pages/login-page.js";
+import { SizesPage } from '../pages/sizes-page.js';
+import { NavigationMenu } from "../pages/navigation-menu.js";
+import { sizeData} from '../../../../support/data.cy.js';
+import { faker } from '@faker-js/faker';
+import { SizesApiHelper } from "../../../api/tests/helpers/sizes-api-helper.js";
+
+const loginPage = new LoginPage()
+const navigationMenu = new NavigationMenu()
+const sizesPage = new SizesPage()
+const sizesApiHelper = new SizesApiHelper()
+
+describe('Sizes Test Suite', () => {
+    beforeEach(() => {
+        cy.clearAllCookies()
+        cy.clearLocalStorage()
+        cy.visit(Cypress.env('baseUrl'))
+        cy.loginByAPI()
+    })
+
+    it('should successfully create a new size', () => {
+        const SUFFIX_LENGTH = 4      
+        sizeData.name = `Size-${faker.string.alphanumeric(SUFFIX_LENGTH).toUpperCase()}`
+
+        loginPage.login(Cypress.env('username'), Cypress.env('password'))
+        navigationMenu.navigateToSizes()
+                
+        sizesPage.createNewSize({
+            sizeName: sizeData.name,
+            sizeDescription: sizeData.description,
+            sizeWidth: sizeData.width,
+            sizeDepth: sizeData.depth,
+            sizeHeight: sizeData.height
+        })
+
+        //Assertions:
+        cy.contains('h2', 'Success').should('be.visible')        
+        cy.contains('p', 'Size created successfully!').should('be.visible').then(()=>{
+            cy.get('@authToken').then((token) => {
+                sizesApiHelper.getSizeByName(token, sizeData.name).then((getSizeByNameResponse)=>{                    
+                    const sizeId = getSizeByNameResponse.body.id
+                    sizesApiHelper.deleteSize(token,sizeId)
+                })
+            })
+            
+            
+
+          })
+
+
+    })
+    
+})

--- a/cypress/support/texts.js
+++ b/cypress/support/texts.js
@@ -44,7 +44,7 @@ export const texts = {
         fileName: 'reservations_template.csv' , 
         userSelection: 'test' , 
 
-    },
+    },       
     addOrganization: {
        selectionAssetMode: 'Asset' , 
        selectionLinkaHardware: 'Linka' , 


### PR DESCRIPTION


https://github.com/user-attachments/assets/3283469c-67f0-481a-bd0c-9bc3e08ea298



**PR Title: Add Cypress Test for adding a Size**
Description:
This PR introduces a new automated test that covers the following functionality:

Creating a Size by UI
Cleaning up by deleting the Size by API to ensure the test environment remains ready for subsequent test runs.
Impact:
Adds coverage for critical operations related to Sizes.
Ensures no residual data affects other test runs, maintaining a consistent testing environment.
Testing Details:
Verified successful creation of Sizes.
Ensured that the cleanup operations remove all test data effectively.